### PR TITLE
Add fluent validation

### DIFF
--- a/ReportHub/ReportHub.Application/Common/Models/ResultModel.cs
+++ b/ReportHub/ReportHub.Application/Common/Models/ResultModel.cs
@@ -1,0 +1,15 @@
+﻿namespace ReportHub.Application.Common.Models;
+
+public class ResultModel<TData, TException>
+{
+    public TData? Data { get; }
+
+    public TException? Exception { get; }
+
+    public bool IsSuccess => Exception is null;
+
+    public ResultModel(TData data) => Data = data;
+
+    public ResultModel(TException exception) => Exception = exception;  
+
+}

--- a/ReportHub/ReportHub.Application/Extensions/DependencyInjection.cs
+++ b/ReportHub/ReportHub.Application/Extensions/DependencyInjection.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using ReportHub.Application.Validators;
 namespace ReportHub.Application.Extensions;
 
 public static class DependencyInjection
@@ -7,7 +9,12 @@ public static class DependencyInjection
     {
         var applicationAssembly = typeof(DependencyInjection).Assembly;
 
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(applicationAssembly));
+        services.AddValidatorsFromAssembly(applicationAssembly);
+
+        services.AddMediatR(cfg => {
+            cfg.RegisterServicesFromAssembly(applicationAssembly);
+            cfg.AddOpenBehavior(typeof(ValidationBehavior<,>));
+        });
 
         services.AddAutoMapper(applicationAssembly);
     }

--- a/ReportHub/ReportHub.Application/Extensions/TaskExtension.cs
+++ b/ReportHub/ReportHub.Application/Extensions/TaskExtension.cs
@@ -1,0 +1,32 @@
+﻿using ReportHub.Application.Common.Models;
+
+namespace ReportHub.Application.Extensions;
+
+public static class TaskExtension
+{
+    /// <summary>
+    /// Gets result model without blocking code execution.
+    /// Usecase: When you want to get result of task without blocking code execution. 
+    /// You do not need to rewrite try catch block again and again
+    /// </summary>
+    /// <typeparam name="TData">
+    /// If the task complated whithout exception this data wrapped into ResultModel and returned as result
+    /// </typeparam>
+    /// <typeparam name="TException">
+    /// If task did not complated in case of exception, this exception type wrapped into ResultModel and returned as result
+    /// </typeparam>
+    /// <param name="task">Actual task to perform which is supposed to get exception </param>
+    /// <returns> ResultModel with data or exception </returns>
+    public static async Task<ResultModel<TData, TException>> GetResultAsync<TData, TException>(this Task<TData> task) 
+        where TException : Exception
+    {
+        try
+        {
+            return new ResultModel<TData, TException>(await task);
+        }
+        catch (TException ex)
+        {
+            return new ResultModel<TData, TException>(ex);
+        }
+    }
+}

--- a/ReportHub/ReportHub.Application/Features/Mapping/InvoiceProfile.cs
+++ b/ReportHub/ReportHub.Application/Features/Mapping/InvoiceProfile.cs
@@ -2,7 +2,7 @@
 using ReportHub.Application.Features.DTOs;
 using ReportHub.Domain.Entities;
 
-namespace ReportHub.Application.Mappings;
+namespace ReportHub.Application.Features.Mapping;
 
 public class InvoiceProfile : Profile
 {

--- a/ReportHub/ReportHub.Application/ReportHub.Application.csproj
+++ b/ReportHub/ReportHub.Application/ReportHub.Application.csproj
@@ -8,6 +8,8 @@
 
 	<ItemGroup>
 	  <PackageReference Include="AutoMapper" Version="14.0.0" />
+	  <PackageReference Include="FluentValidation" Version="11.11.0" />
+	  <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
 	  <PackageReference Include="MediatR" Version="12.4.1" />
 	  <PackageReference Include="Serilog" Version="4.2.0" />
 	  <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/ReportHub/ReportHub.Application/Validation/Exceptions/InputValidationException.cs
+++ b/ReportHub/ReportHub.Application/Validation/Exceptions/InputValidationException.cs
@@ -1,0 +1,12 @@
+﻿namespace ReportHub.Application.Validation.Exceptions;
+
+public class InputValidationException : Exception
+{
+    public IReadOnlyDictionary<string, string[]> Errors { get; }
+
+    public InputValidationException(IReadOnlyDictionary<string, string[]> errors) :
+        base("One or more validation failures have occurred.")
+    {
+        Errors = errors;
+    }
+}

--- a/ReportHub/ReportHub.Application/Validators/Exceptions/InputValidationException.cs
+++ b/ReportHub/ReportHub.Application/Validators/Exceptions/InputValidationException.cs
@@ -1,4 +1,4 @@
-﻿namespace ReportHub.Application.Validation.Exceptions;
+﻿namespace ReportHub.Application.Validators.Exceptions;
 
 public class InputValidationException : Exception
 {

--- a/ReportHub/ReportHub.Application/Validators/ValidationBehavior.cs
+++ b/ReportHub/ReportHub.Application/Validators/ValidationBehavior.cs
@@ -1,0 +1,45 @@
+﻿using FluentValidation;
+using MediatR;
+using ReportHub.Application.Validators.Exceptions;
+using System.Collections.Immutable;
+
+namespace ReportHub.Application.Validators;
+
+class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+     
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (!_validators.Any())
+        {
+            return await next();
+        }
+
+        var context = new ValidationContext<TRequest>(request);
+
+        var validationFailures = await Task.WhenAll(
+            _validators.Select(validator => validator.ValidateAsync(context, cancellationToken)));
+
+        var errors = validationFailures
+                        .Where(validationResult => !validationResult.IsValid)
+                        .SelectMany(validationResult => validationResult.Errors)
+                        .GroupBy(validationFailures => validationFailures.PropertyName)
+                        .ToImmutableDictionary(
+                        pairs => pairs.Key,
+                        pairs => pairs.Select(x => x.ErrorMessage).ToArray());
+
+        if (errors.Any())
+        {
+            throw new InputValidationException(errors);
+        }
+
+        return await next();
+    }
+}


### PR DESCRIPTION
Added fluent validation.

Used libriries:    `FluentValidation` and `FluentValidationDependencyInjectionExtensions`

As there is no input query I did not created any Validator class. Just base functionality **FluentValidation** integration **Mediatr** to automate validation.

Created classes: 

**1.** `InputValidationException` custom exception.
   **Purpose:** Returning all validation exception as one model.

**2.** `ValidationBehavior` pipline class.
  **Purpose:** Validate inputs automatically if  mediatr **QueryHandler** called and has validators. So there is no need to inject `IValidator<T>` class inside of `QueryHandler`

**3** `ResultModel`  application model
  **Purpose:** To return task result with information `IsSuccess` `Data` `Exception`.

**4** `TaskResult` extension class.
 **Method** _GetResultAsync<TData>(this Task<TData> task)_  (_in addition we can also add this to other types like_  **ValueTask<T>** **Func<T>** and etc)
  **Purpose:** as we are using `ValidationBehavior`, it automate validation process and throw exception automatically. In this case what if we want to do other task we create `try` `catch` block. What if we have used it more than one time. It'll definitly break the rool of DRY. So writing it once is good practice