### PR TITLE
Add file base service

### DIFF
--- a/ReportHub/ReportHub.Application/Contracts/FileContracts/IFileReader.cs
+++ b/ReportHub/ReportHub.Application/Contracts/FileContracts/IFileReader.cs
@@ -1,0 +1,6 @@
+﻿namespace ReportHub.Application.Contracts.FileContracts;
+
+public interface IFileReader
+{
+    Task<IEnumerable<T>> ReadAllAsync<T>(Stream stream, CancellationToken cancellationToken) where T : class;
+}

--- a/ReportHub/ReportHub.Application/Contracts/FileContracts/IFileWriter.cs
+++ b/ReportHub/ReportHub.Application/Contracts/FileContracts/IFileWriter.cs
@@ -2,5 +2,5 @@
 
 public interface IFileWriter
 {
-    Task WriteAllAsync<T>(IEnumerable<T> datas, CancellationToken token);
+    Task<Stream> WriteAllAsync<T>(IEnumerable<T> datas, CancellationToken token);
 }

--- a/ReportHub/ReportHub.Application/Contracts/FileContracts/IFileWriter.cs
+++ b/ReportHub/ReportHub.Application/Contracts/FileContracts/IFileWriter.cs
@@ -1,0 +1,6 @@
+﻿namespace ReportHub.Application.Contracts.FileContracts;
+
+public interface IFileWriter
+{
+    Task WriteAllAsync<T>(IEnumerable<T> datas, CancellationToken token);
+}


### PR DESCRIPTION
## Overview
   Added file base interfaces to implement import and export data as file.

## Created interfaces
**1.** `IFileReader` interface responsible for only read data from file.
     **Methods:**
           `Task<IEnumerable<T>> ReadAllAsync<T>(Stream stream, CancellationToken cancellationToken)` gets opened file stream as parameter  and read it from source and convert it to IEnumerable collection.

**2.** `IFileWriter` interface responsible for only writing data inside of file.
     **Methods:**
       ` Task<Stream> WriteAllAsync<T>(IEnumerable<T> datas, CancellationToken cancellationToken)` gets generic collection of 
        data and write it into the stream and return that stream to controller.

Why used different interfaces to write and read?
Answer is, not all files support both writing and reading. So if we create one interface with read and write method, files that are not intended for writing/reading will also include the functionality to write/read, which is bad practice  