### PR TITLE
Separate auth endpoints

### DIFF
--- a/ReportHub/ReportHub.API/Controllers/AdminController.cs
+++ b/ReportHub/ReportHub.API/Controllers/AdminController.cs
@@ -4,7 +4,7 @@ using OpenIddict.Validation.AspNetCore;
 
 namespace ReportHub.API.Controllers;
 
-[Authorize(Roles = "admin",
+[Authorize(Roles = "Admin",
     AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme)]
 [ApiController]
 [Route("api/[controller]")]

--- a/ReportHub/ReportHub.Identity/Controllers/AdminController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/AdminController.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using ReportHub.Identity.Models;
+
+namespace ReportHub.Identity.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class AdminController : ControllerBase
+{
+    private readonly UserManager<User> _userManager;
+    private readonly RoleManager<Role> _roleManager;
+
+    public AdminController(UserManager<User> userManager, RoleManager<Role> roleManager)
+    {
+        _userManager = userManager;
+        _roleManager = roleManager;
+    }
+    [HttpGet("users")]
+    public IActionResult GetAllUsers() => Ok(_userManager.Users.ToList());
+
+    [HttpPost("assign-role")]
+    public async Task<IActionResult> AssignRole([FromBody] AssignRoleRequest request)
+    {
+
+        var user = await _userManager.FindByNameAsync(request.Username);
+
+        if (user is null)
+            return NotFound("User not found");
+
+        var roleExists = await _roleManager.RoleExistsAsync(request.RoleName);
+
+        if (!roleExists)
+            return BadRequest("Role does not exist");
+
+        var result = await _userManager.AddToRoleAsync(user, request.RoleName);
+
+        if (result.Succeeded)
+            return Ok("Role assigned successfully");
+
+        return BadRequest(result.Errors);
+    }
+}

--- a/ReportHub/ReportHub.Identity/Controllers/AdminController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/AdminController.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using ReportHub.Identity.Models;
 
 namespace ReportHub.Identity.Controllers;
-
+[Authorize(Roles = "Admin")]
 [Route("api/[controller]")]
 [ApiController]
 public class AdminController : ControllerBase

--- a/ReportHub/ReportHub.Identity/Controllers/AdminController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/AdminController.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Validation.AspNetCore;
 using ReportHub.Identity.Models;
 
 namespace ReportHub.Identity.Controllers;
-[Authorize(Roles = "Admin")]
+[Authorize(Roles = "Admin", AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme)]
 [Route("api/[controller]")]
 [ApiController]
 public class AdminController : ControllerBase

--- a/ReportHub/ReportHub.Identity/Controllers/AdminController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/AdminController.cs
@@ -40,4 +40,17 @@ public class AdminController : ControllerBase
 
         return BadRequest(result.Errors);
     }
+
+    [HttpGet("{userId}/roles")]
+    public async Task<IActionResult> GetUserRoles(string userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+
+        if (user is null)
+            return NotFound("User not found");
+
+        var roles = await _userManager.GetRolesAsync(user);
+
+        return Ok(roles);
+    }
 }

--- a/ReportHub/ReportHub.Identity/Controllers/AuthController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/AuthController.cs
@@ -127,7 +127,7 @@ public class AuthController : ControllerBase
 
         ClaimsIdentity identity = GetIdentityClaims();
 
-        SetClaims(request, role, result.user!, identity);
+        SetClaims(request, result.user!, identity, role);
 
         identity.SetScopes(request.GetScopes());
 
@@ -203,7 +203,7 @@ public class AuthController : ControllerBase
         }
     }
 
-    private void SetClaims(OpenIddictRequest request, string role = "User", User user, ClaimsIdentity identity)
+    private void SetClaims(OpenIddictRequest request, User user, ClaimsIdentity identity, string role = "User")
     {
         identity
                     .SetClaim(Claims.Subject, request.ClientId)

--- a/ReportHub/ReportHub.Identity/Controllers/AuthController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/AuthController.cs
@@ -26,7 +26,7 @@ public class AuthController : ControllerBase
         _userManager = userManager;
     }
 
-    [HttpPost("~/connect/token"), Produces("application/json")]
+    [HttpPost("/auth/login-as-admin"), Produces("application/json")]
     public async Task<IActionResult> Exchange()
     {
         var request = HttpContext.GetOpenIddictServerRequest()

--- a/ReportHub/ReportHub.Identity/Controllers/AuthController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/AuthController.cs
@@ -8,6 +8,7 @@ using OpenIddict.Server.AspNetCore;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using Microsoft.IdentityModel.Tokens;
 using ReportHub.Identity.Models;
+using System.Threading.Tasks;
 
 namespace ReportHub.Identity.Controllers;
 
@@ -26,99 +27,6 @@ public class AuthController : ControllerBase
         _userManager = userManager;
     }
 
-    [HttpPost("/auth/login-as-admin"), Produces("application/json")]
-    public async Task<IActionResult> Exchange()
-    {
-        var request = HttpContext.GetOpenIddictServerRequest()
-                      ?? throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
-
-        if (request.ClientId is null)
-        {
-            return BadRequest(new OpenIddictResponse
-            {
-                Error = Errors.InvalidClient,
-                ErrorDescription = "The client_id parameter is missing."
-            });
-        }
-
-        var user = await _userManager.FindByNameAsync(request.Username);
-        if (user is null)
-        {
-            return BadRequest(new OpenIddictResponse
-            {
-                Error = Errors.InvalidGrant,
-                ErrorDescription = "The user name or password is invalid."
-            });
-        }
-
-        var isValidPassword = await _userManager.CheckPasswordAsync(user, request.Password);
-        if (!isValidPassword)
-        {
-            return BadRequest(new OpenIddictResponse
-            {
-                Error = Errors.InvalidGrant,
-                ErrorDescription = "The user name or password is invalid."
-            });
-        }
-
-        if (request.IsClientCredentialsGrantType() || request.IsPasswordGrantType())
-        {
-            if (await _applicationManager.FindByClientIdAsync(request.ClientId) is null)
-                throw new InvalidOperationException("The application cannot be found.");
-
-            var identity = new ClaimsIdentity(
-                authenticationType: TokenValidationParameters.DefaultAuthenticationType,
-                nameType: Claims.Name,
-                roleType: Claims.Role);
-
-            var userRoles = await _userManager.GetRolesAsync(user);
-
-            identity
-                .SetClaim(Claims.Subject, request.ClientId)
-                .SetClaim(Claims.Audience, "report-hub-api-audience")
-                .SetClaim(Claims.Email, await _userManager.GetEmailAsync(user))
-                .SetClaim(Claims.Name, await _userManager.GetUserNameAsync(user))
-                .SetClaims(Claims.Role, [.. userRoles]);
-
-            identity.SetScopes(request.GetScopes());
-
-            var principal = new ClaimsPrincipal(identity);
-
-            foreach (var claim in principal.Claims)
-            {
-                claim.SetDestinations(Destinations.AccessToken, Destinations.IdentityToken);
-            }
-
-            return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-        }
-
-        if (request.IsRefreshTokenGrantType())
-        {
-            var principal = (await HttpContext.AuthenticateAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)).Principal;
-            if (principal is null)
-            {
-                return BadRequest(new OpenIddictResponse
-                {
-                    Error = Errors.InvalidGrant,
-                    ErrorDescription = "Invalid refresh token."
-                });
-            }
-
-            var identity = new ClaimsIdentity(TokenValidationParameters.DefaultAuthenticationType);
-            identity.SetClaim(Claims.Subject, principal.GetClaim(Claims.Subject));
-            identity.SetClaim(Claims.Audience, "report-hub-api-audience");
-
-            identity.SetDestinations(_ => [Destinations.AccessToken, "refresh_token"]);
-
-            return SignIn(new ClaimsPrincipal(identity), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-        }
-
-        return BadRequest(new OpenIddictResponse
-        {
-            Error = Errors.InvalidGrant,
-            ErrorDescription = "The specified grant type is not supported."
-        });
-    }
 
     [HttpPost("sign-up")]
     public async Task<IActionResult> SignUp([FromBody] SignUpRequest request)
@@ -142,5 +50,133 @@ public class AuthController : ControllerBase
         }
 
         return Ok("User registered successfully.");
+    }
+
+    [HttpPost("/auth/login-as-admin"), Produces("application/json")]
+    public async Task<IActionResult> LoginAsAdmin()
+    {
+        OpenIddictRequest request = GetOpenIddictRequest();
+
+        if (!request.IsClientCredentialsGrantType() && !request.IsPasswordGrantType())
+        {
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = Errors.InvalidGrant,
+                ErrorDescription = "The specified grant type is not supported."
+            });
+        }
+
+        if (request.ClientId is null)
+        {
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = Errors.InvalidClient,
+                ErrorDescription = "The client_id parameter is missing."
+            });
+        }
+
+        return await LoginAs(request, "Admin");
+    }
+
+    [HttpPost("/auth/login-as-client"), Produces("application/json")]
+    public async Task<IActionResult> LoginAsClient()
+    {
+        OpenIddictRequest request = GetOpenIddictRequest();
+
+        if (!request.IsClientCredentialsGrantType() && !request.IsPasswordGrantType())
+        {
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = Errors.InvalidGrant,
+                ErrorDescription = "The specified grant type is not supported."
+            });
+        }
+
+        if (request.ClientId is null)
+        {
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = Errors.InvalidClient,
+                ErrorDescription = "The client_id parameter is missing."
+            });
+        }
+
+        return await LoginAs(request, "Client");
+    }
+
+    private async Task<IActionResult> LoginAs(OpenIddictRequest request, string role)
+    {
+        var result = await ValidateUserCreadentials(request.Username!, request.Password!);
+
+        if (!result.isSuccess)
+        {
+            return BadRequest(new OpenIddictResponse
+            {
+                Error = Errors.InvalidGrant,
+                ErrorDescription = "The user name or password is invalid."
+            });
+        }
+
+
+        if (await _applicationManager.FindByClientIdAsync(request.ClientId) is null)
+            throw new InvalidOperationException("The application cannot be found.");
+
+        if (!await _userManager.IsInRoleAsync(result.user!, role))
+        {
+            return Forbid();
+        }
+
+        ClaimsIdentity identity = GetIdentityClaims();
+
+        SetClaims(request, role, result.user!, identity);
+
+        identity.SetScopes(request.GetScopes());
+
+        var principal = new ClaimsPrincipal(identity);
+
+        SetDestinations(principal);
+
+        return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+
+    private async Task<(User? user, bool isSuccess)> ValidateUserCreadentials(string userName, string password)
+    {
+        var user = await _userManager.FindByNameAsync(userName);
+
+        var isSuccess = user is not null && await _userManager.CheckPasswordAsync(user, password);
+
+        return (user, isSuccess);
+    }
+
+    private static void SetDestinations(ClaimsPrincipal principal)
+    {
+        foreach (var claim in principal.Claims)
+        {
+            claim.SetDestinations(Destinations.AccessToken, Destinations.IdentityToken);
+        }
+    }
+
+    private void SetClaims(OpenIddictRequest request, string role, User user, ClaimsIdentity identity)
+    {
+        identity
+                    .SetClaim(Claims.Subject, request.ClientId)
+                    .SetClaim(Claims.Audience, "report-hub-api-audience")
+                    .SetClaim(Claims.Email, user.Email)
+                    .SetClaim(Claims.Name, user.UserName)
+                    .SetClaims(Claims.Role, [role]);
+    }
+
+    private static ClaimsIdentity GetIdentityClaims()
+    {
+        return new ClaimsIdentity(
+            authenticationType: TokenValidationParameters.DefaultAuthenticationType,
+            nameType: Claims.Name,
+            roleType: Claims.Role);
+    }
+
+    private OpenIddictRequest GetOpenIddictRequest()
+    {
+        return HttpContext.GetOpenIddictServerRequest()
+                      ?? throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
     }
 }

--- a/ReportHub/ReportHub.Identity/Controllers/RolesController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/RolesController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using ReportHub.Identity.Models;
-using System.Threading.Tasks;
 
 namespace ReportHub.Identity.Controllers;
 

--- a/ReportHub/ReportHub.Identity/Controllers/RolesController.cs
+++ b/ReportHub/ReportHub.Identity/Controllers/RolesController.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using ReportHub.Identity.Models;
+using System.Threading.Tasks;
+
+namespace ReportHub.Identity.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class RolesController : ControllerBase
+{
+    private readonly RoleManager<Role> _roleManager;
+
+    public RolesController(RoleManager<Role> roleManager)
+    {
+        _roleManager = roleManager;
+    }
+
+    [HttpGet]
+    public IActionResult Get() => Ok(_roleManager.Roles.Select(r => r.Name).ToList());
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] RoleCreation newRole)
+    {
+        if (string.IsNullOrWhiteSpace(newRole.Name))
+            return BadRequest("Role name cannot be empty.");
+
+        var result = await _roleManager.CreateAsync(new Role(newRole.Name));
+        
+        if (result.Succeeded)
+            return Created();
+
+        return BadRequest(result.Errors);
+    }
+}

--- a/ReportHub/ReportHub.Identity/Models/AssignRoleRequest.cs
+++ b/ReportHub/ReportHub.Identity/Models/AssignRoleRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace ReportHub.Identity.Models;
+
+public class AssignRoleRequest
+{
+    public string Username { get; set; } = string.Empty;
+
+    public string RoleName { get; set; } = string.Empty;
+}

--- a/ReportHub/ReportHub.Identity/Models/RoleCreation.cs
+++ b/ReportHub/ReportHub.Identity/Models/RoleCreation.cs
@@ -1,0 +1,6 @@
+﻿namespace ReportHub.Identity.Models;
+
+public class RoleCreation
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/ReportHub/ReportHub.Identity/Program.cs
+++ b/ReportHub/ReportHub.Identity/Program.cs
@@ -63,7 +63,7 @@ builder.Services.AddOpenIddict()
     .AddServer(options =>
     {
         options.SetIssuer(new Uri(authSettings.Issuer));
-        options.SetTokenEndpointUris("auth/login-as-admin", "auth/login-as-client")
+        options.SetTokenEndpointUris("auth/login-as-admin", "auth/login-as-client", "auth/refresh-token")
             .AllowPasswordFlow()
             .AllowRefreshTokenFlow()
             .AllowClientCredentialsFlow();

--- a/ReportHub/ReportHub.Identity/Program.cs
+++ b/ReportHub/ReportHub.Identity/Program.cs
@@ -1,6 +1,8 @@
 using System.Security.Claims;
 using AspNetCore.Identity.Mongo;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using OpenIddict.Abstractions;
 using OpenIddict.Server;
@@ -22,6 +24,33 @@ builder.Services.AddSwaggerGen(c =>
         Title = "ReportHub.Identity",
         Version = "v1"
     });
+
+    c.AddSecurityDefinition(name: JwtBearerDefaults.AuthenticationScheme, securityScheme: new OpenApiSecurityScheme()
+    {
+        Name = "Authorization",
+        Description = "Enter the Bearer Authorization string as following: `Bearer` Generated-JWT-Token",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = JwtBearerDefaults.AuthenticationScheme
+    });
+
+    c
+    .AddSecurityRequirement(
+            new OpenApiSecurityRequirement()
+            {
+            {
+                new OpenApiSecurityScheme()
+                {
+                    Reference = new OpenApiReference()
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = JwtBearerDefaults.AuthenticationScheme
+                    }
+                },
+                new string[]{}
+            }
+            }
+    );
 });
 
 var authSettings = builder.Configuration.GetSection("Authentication").Get<AuthSettings>();
@@ -70,7 +99,7 @@ builder.Services.AddOpenIddict()
 
         options.DisableAccessTokenEncryption();
 
-        options.SetIntrospectionEndpointUris("/connect/introspect");
+        options.SetIntrospectionEndpointUris("connect/introspect");
 
         options.RegisterScopes(
             OpenIddictConstants.Scopes.Email,

--- a/ReportHub/ReportHub.Identity/Program.cs
+++ b/ReportHub/ReportHub.Identity/Program.cs
@@ -63,7 +63,7 @@ builder.Services.AddOpenIddict()
     .AddServer(options =>
     {
         options.SetIssuer(new Uri(authSettings.Issuer));
-        options.SetTokenEndpointUris("auth/login-as-admin")
+        options.SetTokenEndpointUris("auth/login-as-admin", "auth/login-as-client")
             .AllowPasswordFlow()
             .AllowRefreshTokenFlow()
             .AllowClientCredentialsFlow();

--- a/ReportHub/ReportHub.Identity/Program.cs
+++ b/ReportHub/ReportHub.Identity/Program.cs
@@ -63,7 +63,7 @@ builder.Services.AddOpenIddict()
     .AddServer(options =>
     {
         options.SetIssuer(new Uri(authSettings.Issuer));
-        options.SetTokenEndpointUris("connect/token")
+        options.SetTokenEndpointUris("auth/login-as-admin")
             .AllowPasswordFlow()
             .AllowRefreshTokenFlow()
             .AllowClientCredentialsFlow();

--- a/ReportHub/ReportHub.Identity/Program.cs
+++ b/ReportHub/ReportHub.Identity/Program.cs
@@ -1,8 +1,6 @@
-using System.Security.Claims;
 using AspNetCore.Identity.Mongo;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using OpenIddict.Abstractions;
 using OpenIddict.Server;
@@ -11,6 +9,7 @@ using ReportHub.Identity.Configurations;
 using ReportHub.Identity.Contexts;
 using ReportHub.Identity.Models;
 using ReportHub.Identity.Workers;
+using System.Security.Claims;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/ReportHub/ReportHub.Identity/Properties/launchSettings.json
+++ b/ReportHub/ReportHub.Identity/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": ".well-known/openid-configuration",
-      "applicationUrl": "https://localhost:7153;",
+      "applicationUrl": "https://localhost:7153;https://localhost:7171",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/ReportHub/ReportHub.Identity/ReportHub.Identity.csproj
+++ b/ReportHub/ReportHub.Identity/ReportHub.Identity.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
       <PackageReference Include="AspNetCore.Identity.Mongo" Version="10.1.0" />
       <PackageReference Include="AspNetCore.Identity.MongoDbCore" Version="6.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
       <PackageReference Include="MongoDB.Driver" Version="3.2.1" />
       <PackageReference Include="OpenIddict" Version="6.2.0" />
       <PackageReference Include="OpenIddict.Client.AspNetCore" Version="6.2.0" />


### PR DESCRIPTION
## Overview
**1.** Separated `connect/token` to `auth/login-as-admin` , `auth/login-as-client` and `auth/refresh-token`.
**2.** managing system roles. Getting all, adding new role is implemented.
**3.** Assingning role for user.

## Usecase
Since we are using `OpenIddict` library for identity we are not able to send request to menstioned urls with swagger. 
So I recommend to use send request for these 3 urls with postman.

1.  for login as admin. 
![image](https://github.com/user-attachments/assets/683bdde1-ebf2-45e8-830e-f6eb2e55f5d8)

2. For login as client just update the url request is same.

3. for get refresh token we do not really need user credential like username, email, password and etc. so its like this 
![image](https://github.com/user-attachments/assets/9afa6808-2005-4359-b895-1cd9c31b60f5)
